### PR TITLE
feat: GitHub Pagesデプロイをdocs/ディレクトリ変更時のみに限定

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,9 @@ name: Deploy GitHub Pages
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 概要
GitHub Pagesへのデプロイを`docs/`ディレクトリに変更があった場合のみ実行するようGitHub Actionsワークフローを更新しました。

Closes #9

## 変更内容
- GitHub Actionsワークフローにパスフィルターを追加
- `docs/**`と`.github/workflows/deploy-pages.yml`の変更を監視
- `workflow_dispatch`による手動デプロイも引き続き可能

## 技術詳細
```yaml
on:
  push:
    branches: [ main ]
    paths:
      - 'docs/**'
      - '.github/workflows/deploy-pages.yml'
  workflow_dispatch:
```

## メリット
- 不要なデプロイを削減
- GitHub Actionsの実行時間を最適化
- Webサイトに関係ない変更でのデプロイを防止

## レビュー確認事項

### 🎯 このPRで特に確認してほしいポイント
- パスフィルターの設定が適切か
- ワークフロー自体の変更も監視対象に含めるべきか

### ⚡ 動作確認
- [ ] docs/ディレクトリ内のファイルを変更した際にデプロイが実行される
- [ ] docs/以外のファイルのみを変更した際にデプロイがスキップされる
- [ ] 手動デプロイ（workflow_dispatch）が引き続き動作する

### 🔍 既存機能への影響確認
- [ ] 既存のGitHub Pagesサイトへの影響なし
- [ ] 他のGitHub Actionsワークフローとの競合なし

🤖 Generated with [Claude Code](https://claude.ai/code)